### PR TITLE
gensim 4.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,15 +22,17 @@ requirements:
   host:
     - python
     - pip
-    - numpy >=1.11.3
     - cython ==0.29.23
+    - numpy >=1.17.0
+    - setuptools
+    - wheel
   run:
     - python
-    - numpy >=1.11.3
+    - {{ pin_compatible('numpy') }}
+    - cython ==0.29.23
+    - dataclasses   # [py<37]
     - scipy >=0.18.1
     - smart_open >=1.8.1
-    - cython ==0.29.23
-    - dataclasses   #[py<37]
 
 test:
   requires:
@@ -40,6 +42,7 @@ test:
     - cython
     - pyemd
     - mock
+    - pip
   imports:
     - gensim
     - gensim.corpora
@@ -49,10 +52,13 @@ test:
     - gensim.similarities
     - gensim.test
     - gensim.topic_coherence
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/RaRe-Technologies/gensim
+  home: https://github.com/RaRe-Technologies/gensim
   license: LGPL-2.1-only
+  license_family: LGPL
   license_file: COPYING
   summary: Topic Modelling for Humans
   description: |
@@ -60,7 +66,7 @@ about:
     and similarity retrieval with large corpora.
     Target audience is the natural language processing (NLP)
     and information retrieval (IR) community.
-  doc_url: http://radimrehurek.com/gensim/
+  doc_url: https://radimrehurek.com/gensim/
   dev_url: https://github.com/RaRe-Technologies/gensim
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gensim" %}
-{% set version = "4.0.1" %}
-{% set sha256 = "b4d0b9562796968684028e06635e0f7aff39ffb33719057fd1667754ea09a6e4" %}
+{% set version = "4.1.2" %}
+{% set sha256 = "1932c257de4eccbb64cc40d46e8577a25f5f47b94b96019a969fb36150f11d15" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,14 @@ requirements:
   host:
     - python
     - pip
-    - cython ==0.29.23
+    - cython >=0.29.23
     - numpy >=1.17.0
     - setuptools
     - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - cython ==0.29.23
+    - cython >=0.29.23
     - dataclasses   # [py<37]
     - scipy >=0.18.1
     - smart_open >=1.8.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0 
-  skip: true  # [py<36]
+  # gensim and pyemd currently aren't available on s390x
+  skip: true  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -40,9 +41,10 @@ test:
     - testfixtures
     - morfessor
     - cython
-    - pyemd
+    - pyemd  # [not (linux and s390x)]
     - mock
     - pip
+    - google-cloud-core >=1.7.1  # [osx and arm64]
   imports:
     - gensim
     - gensim.corpora


### PR DESCRIPTION
Update gensim to 4.1.2

Changelog: https://github.com/RaRe-Technologies/gensim/blob/4.1.2/CHANGELOG.md
License: https://github.com/RaRe-Technologies/gensim/blob/4.1.2/COPYING
Upstream setup.py: https://github.com/RaRe-Technologies/gensim/blob/4.1.2/setup.py

Actions: 
1. Update host and run dependencies
2. Add pip check
3. Fix home and doc urls with HTTPS
4. Add license_family